### PR TITLE
Add links to community calendar/notes doc and Slack invite

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -20,3 +20,16 @@ Where a gap exists in the current open source offering, StreamsHub aims to host 
 - **Contribute documentation and tutorials:** Help improve best-practice guides and tutorials on the [StreamsHub website](https://www.streamshub.io/) ([source](https://github.com/streamshub/streamshub-site)).
 - **Report issues and contribute code:** Each project repository welcomes issues and pull requests.
 - **Governance:** Community Governance (code of conduct, voting rules, etc.) is covered in the [Governance Repository](https://github.com/streamshub/governance)
+
+### Community Slack
+
+The main way to interact officially with the StreamsHub community is via the Proposals repository and Issues/PRs on the relevant project repositories. However, there is a community Slack workspace for more free-form conversations:
+
+[Slack Invite Link](https://join.slack.com/t/streamshub-io/shared_invite/zt-3qv16izwl-1BpMlPVhv6D3F_OoxpybDg)
+
+### Community Call
+
+The StreamsHub community call is usually held bi-weekly:
+- Meetings are scheduled on the StreamsHub Google Calendar: [Web](https://calendar.google.com/calendar/embed?src=fad0c9b9be278955809bc8e47806f7a17a70b7112dfc145ca8f497c318612b1d%40group.calendar.google.com&ctz=Europe%2FLondon) / [iCal](https://calendar.google.com/calendar/ical/fad0c9b9be278955809bc8e47806f7a17a70b7112dfc145ca8f497c318612b1d%40group.calendar.google.com/public/basic.ics)
+- Meeting agenda and notes are stored in this [Google Doc](https://calendar.google.com/calendar/ical/fad0c9b9be278955809bc8e47806f7a17a70b7112dfc145ca8f497c318612b1d%40group.calendar.google.com/public/basic.ics)
+- Please add any discussion items to the agenda at least 12 hours before the meeting starts. If there are no agenda items or significant proposals/issues/PRs to discuss, the maintainers reserve the right to cancel the meeting. Cancellations will be announced on the `#all-streamshub` channel on the community Slack.


### PR DESCRIPTION
This PR adds details of how people can join the community call, add agenda items and join the community Slack.